### PR TITLE
Labs | RemoveDeleteBtn style option // Auto nav buttons disable

### DIFF
--- a/Killer/Services/EmbedPagesService.cs
+++ b/Killer/Services/EmbedPagesService.cs
@@ -39,12 +39,12 @@ namespace KillersLibrary.Services {
                 if (interaction.Data.Type != ComponentType.Button) return;
 
                 if (interaction.Message.Id == currentMessage.Id && interaction.User.Id == CommonService.Instance.GetAuthorID(context, command)) {
-                    currentPage = await FinishEmbedActions(interaction, embedBuilders, currentPage, currentMessage, componentBuilder, styles, extraButtons);
+                    currentPage = await FinishEmbedActions(interaction, embedBuilders, currentPage, currentMessage, styles, extraButtons);
                 }
             };
         }
 
-        private async Task<int> FinishEmbedActions(SocketMessageComponent interaction, List<EmbedBuilder> embedBuilders, int currentPage, RestUserMessage currentMessage, ComponentBuilder componentBuilder, EmbedPagesStyles styles, ButtonBuilder[] extraButtons) {
+        private async Task<int> FinishEmbedActions(SocketMessageComponent interaction, List<EmbedBuilder> embedBuilders, int currentPage, RestUserMessage currentMessage, EmbedPagesStyles styles, ButtonBuilder[] extraButtons) {
             currentPage = GetCurrentPage(interaction, currentPage, embedBuilders);
 
             switch (interaction.Data.CustomId) {

--- a/Killer/Services/EmbedPagesService.cs
+++ b/Killer/Services/EmbedPagesService.cs
@@ -87,9 +87,11 @@ namespace KillersLibrary.Services {
         }
 
         private ComponentBuilder GetComponentBuilder(EmbedPagesStyles styles, ButtonBuilder[] extraButtons = null) {
-            int buttonCount = 3;
+            int buttonCount = 2;
+            
             ComponentBuilder componentBuilder = new();
             ButtonBuilder buttonBuilder;
+            
             if (styles.FastChangeBtns) {
                 buttonBuilder = new ButtonBuilder()
                     .WithCustomId("killer_first_embed")
@@ -105,11 +107,15 @@ namespace KillersLibrary.Services {
                 .WithStyle(styles.BtnColor);
             componentBuilder.WithButton(buttonBuilder);
 
-            buttonBuilder = new ButtonBuilder()
-            .WithCustomId("killer_delete_embed_pages")
-                .WithEmote(new Emoji(styles.DeletionEmoji ?? "🗑"))
-                .WithStyle(styles.DeletionBtnColor);
-            componentBuilder.WithButton(buttonBuilder);
+            if (!styles.RemoveDeleteBtn)
+            {
+                buttonBuilder = new ButtonBuilder()
+                .WithCustomId("killer_delete_embed_pages")
+                    .WithEmote(new Emoji(styles.DeletionEmoji ?? "🗑"))
+                    .WithStyle(styles.DeletionBtnColor);
+                componentBuilder.WithButton(buttonBuilder);
+                buttonCount++;
+            }
 
             buttonBuilder = new ButtonBuilder()
             .WithCustomId("killer_forward_button_embed")
@@ -142,6 +148,7 @@ namespace KillersLibrary.Services {
         public string FirstLabel { get; set; } = "«";
         public string BackLabel { get; set; } = "‹";
         public string DeletionEmoji { get; set; } = "🗑";
+        public bool RemoveDeleteBtn { get; set; } = false;
         public string ForwardLabel { get; set; } = "›";
         public string LastLabel { get; set; } = "»";
         public string DeletionMessage { get; set; } = "Embed page has been deleted";

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ public async Task HelpAsync() {
     style.SkipBtnColor = ButtonStyle.Primary;
     style.FastChangeBtns = false; // Do you want there to be a button that goes directly to either ends?
     style.PageNumbers = true; //Do you want the embed to have page numbers like "Page: 1/4"? Depends on how many pages you have.
+    style.RemoveDeleteBtn = false; // Do you want to remove the Delete button (trash icon)?
     
     await _embedPagesService.CreateEmbedPages(client, embedBuilders, context, style: style);
     // await _embedPagesService.CreateEmbedPages(client, embedBuilders, command: command, style: style); //Or slashcommands


### PR DESCRIPTION
Added the option to remove the the Delete button from the buttonBuilder.

You can use `style.RemoveDeleteBtn = false;` in the EmbedPagesStyles to either Remove, or Keep the Delete button.

(style.RemoveDeleteBtn is false by default if you do not specify it in the EmbedPagesStyles)